### PR TITLE
初回実行時にFailする幾つかの点を更新

### DIFF
--- a/lib/itamae/plugin/recipe/nginx_build/install.rb
+++ b/lib/itamae/plugin/recipe/nginx_build/install.rb
@@ -65,8 +65,8 @@ if modules3rd_path =~ /^(.+)\/([^\/]+)$/
 end
 
 execute "build-nginx" do
-  command "#{nginx_build_bin}nginx-build -d work -v #{nginx_version} -c #{configure_path} -m #{modules3rd_path}"
-  command "cd ~/work/nginx/#{nginx_version}/nginx-#{nginx_version} && sudo make install"
+  command "#{nginx_build_bin}nginx-build -d work -v #{nginx_version} -c #{configure_path} -m #{modules3rd_path} && \
+           cd ~/work/nginx/#{nginx_version}/nginx-#{nginx_version} && sudo make install"
   action :nothing
 end
 
@@ -80,8 +80,11 @@ template "/etc/init.d/nginx" do
                 "nginx_conf" => nginx_conf,
                 "nginx_pid"  => nginx_pid,
             })
+  notifies :enable, 'service[nginx]', :delayed
+  notifies :start, 'service[nginx]', :delayed
 end
 
 service 'nginx' do
   action [:enable, :start]
+  only_if "test -f #{nginx_sbin}"
 end

--- a/lib/itamae/plugin/recipe/nginx_build/templates/modules3rd.ini.erb
+++ b/lib/itamae/plugin/recipe/nginx_build/templates/modules3rd.ini.erb
@@ -2,6 +2,11 @@
 [<%=m[:name]%>]
 form=<%=m[:form]%>
 url=<%=m[:url]%>
-rev=<%=m[:rev]%>
-
-<% end %>
+rev=<%=m[:rev] || 'master'%>
+<% if m[:shprov] -%>
+shprov=<%=m[:shprov]%>
+<% end -%>
+<% if m[:shprovdir] -%>
+shprovdir=<%=m[:shprovdir]%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
- `execute[build-nginx]` にcommandが2つあって、後勝ちになっていなのでつなげました。
- notifiesの都合で、`execute[build-nginx]`が実行される前に`service[nginx]`が処理されることがあるため、バイナリの存在確認を入れました。
  - このチェックによりバイナリが初めて作成される際にサービスが起動しないので、最後に並ぶようにしました。

---

追記:
- 3rdパーティモジュールのテンプレートに、現行のパラメータを追加しました。
